### PR TITLE
VSCode でデバッグするための設定

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug Local File",
+            "type": "Ruby",
+            "request": "launch",
+            "cwd": "${workspaceFolder}",
+            "program": "${file}",
+            "pathToRDebugIDE": "/usr/local/bundle/gems/ruby-debug-ide-0.7.2/lib/ruby-debug-ide"
+        },
+    ]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,5 @@
 FROM ruby:2.5
+
+COPY Gemfile /tmp/
+WORKDIR /tmp
+RUN bundle install


### PR DESCRIPTION
#4 の対応。

### 更新内容
- デバッグ用の設定を追加
- デバッグに必要な Gem をインストールするように Dockerfile を更新